### PR TITLE
fix: ensure `connectedCallback` runs after Ember initializer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-custom-elements",
-  "version": "0.1.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "broccoli-string-replace": "^0.1.2",
     "ember-cli-babel": "^7.18.0",
     "ember-cli-babel-plugin-helpers": "^1.1.0",
-    "ember-cli-htmlbars": "^4.2.3"
+    "ember-cli-htmlbars": "^4.2.3",
+    "rsvp": "^4.8.5"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",


### PR DESCRIPTION
This resolves an issue where the initialization logic was being run in the constructor of the custom element _before_ the Ember initializer was finished. The result of this issue was that the custom element attempted to access properties that were not yet ready for access.

The Ember initializer creates a new promise on each run to ensure that, in a testing scenario, each initializer run gets it's own promise. This isn't strictly necessary, but is probably safer for testing purposes.

Related to #6